### PR TITLE
Feature: Ads Analytics wrapper

### DIFF
--- a/react/AdsAnalytics.tsx
+++ b/react/AdsAnalytics.tsx
@@ -1,0 +1,3 @@
+import { AdsAnalytics } from './components/AdsAnalytics'
+
+export default AdsAnalytics

--- a/react/__testUtils__/factories/product.ts
+++ b/react/__testUtils__/factories/product.ts
@@ -1,0 +1,21 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'rosie'
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+const ProductFactory = Factory.define<Partial<Product>>('product')
+  .option('isSponsored', true)
+  .attr('productId', faker.string.uuid)
+  .attr('productName', faker.commerce.productName())
+  .attr('advertisement', ['isSponsored'], (isSponsored: boolean) => {
+    if (!isSponsored) return
+
+    return {
+      adId: faker.string.uuid(),
+      campaignId: faker.string.uuid(),
+      adRequestId: faker.string.uuid(),
+      adResponseId: faker.string.uuid(),
+      actionCost: faker.number.float({ min: 0, max: 5, precision: 0.01 }),
+    }
+  })
+
+export default ProductFactory

--- a/react/components/AdsAnalytics/AdsAnalytics.tsx
+++ b/react/components/AdsAnalytics/AdsAnalytics.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { isSponsored } from '../../utils'
+import { AdsAnalyticsProps } from './AdsAnalytics.types'
+import { getDataProperties } from './utils'
+
+export const AdsAnalytics = ({
+  ProductSummary,
+  ...productSummaryProps
+}: AdsAnalyticsProps) => {
+  const { product, position } = productSummaryProps
+
+  if (!isSponsored(product)) return <ProductSummary {...productSummaryProps} />
+
+  const dataProperties = getDataProperties({ product, position })
+
+  return (
+    <div {...dataProperties} data-testid="ads-analytics">
+      <ProductSummary {...productSummaryProps} />
+    </div>
+  )
+}

--- a/react/components/AdsAnalytics/AdsAnalytics.types.tsx
+++ b/react/components/AdsAnalytics/AdsAnalytics.types.tsx
@@ -1,0 +1,22 @@
+import { ProductSummaryTypes } from 'vtex.product-summary-context'
+
+type ProductSummaryProps = {
+  product: ProductSummaryTypes.Product
+  position: number
+  [x: string]: unknown
+}
+
+export type AdsAnalyticsProps = {
+  ProductSummary: React.FC<ProductSummaryProps>
+} & ProductSummaryProps
+
+export type DataProperties = {
+  'data-van-prod-id': string
+  'data-van-prod-name': string
+  'data-van-position': number
+  'data-van-aid': string
+  'data-van-cid': string
+  'data-van-req-id': string
+  'data-van-res-id': string
+  'data-van-cpc': number
+}

--- a/react/components/AdsAnalytics/__tests__/AdsAnalytics.test.tsx
+++ b/react/components/AdsAnalytics/__tests__/AdsAnalytics.test.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom'
+import { render } from '@vtex/test-tools/react'
+import React from 'react'
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+import ProductFactory from '../../../__testUtils__/factories/product'
+import { AdsAnalytics } from '../AdsAnalytics'
+
+const testId = 'product-summary'
+const MockProductSummary = () => <div data-testid={testId}>ProductSummary</div>
+
+const position = 1
+
+const setupTest = (product: Product) => {
+  return render(
+    <AdsAnalytics
+      ProductSummary={MockProductSummary}
+      product={product}
+      position={position}
+    />
+  )
+}
+
+describe('<AdsAnalytics />', () => {
+  describe('when a product is sponsored', () => {
+    const product = ProductFactory.build() as Product
+
+    it('should render the ProductSummary component passed as prop', () => {
+      const { getByTestId } = setupTest(product)
+
+      expect(getByTestId(testId)).toBeInTheDocument()
+    })
+
+    it('should add a wrapper with the correct data properties', () => {
+      const { getByTestId } = setupTest(product)
+      const wrapper = getByTestId('ads-analytics')
+      const {
+        productId,
+        productName,
+        advertisement: {
+          campaignId,
+          adId,
+          adRequestId,
+          adResponseId,
+          actionCost,
+        },
+      } = product
+
+      expect(wrapper.getAttribute('data-van-prod-id')).toBe(productId)
+      expect(wrapper.getAttribute('data-van-prod-name')).toBe(productName)
+      expect(wrapper.getAttribute('data-van-position')).toBe('1')
+      expect(wrapper.getAttribute('data-van-cid')).toBe(campaignId)
+      expect(wrapper.getAttribute('data-van-aid')).toBe(adId)
+      expect(wrapper.getAttribute('data-van-req-id')).toBe(adRequestId)
+      expect(wrapper.getAttribute('data-van-res-id')).toBe(adResponseId)
+      expect(wrapper.getAttribute('data-van-cpc')).toBe(actionCost.toString())
+    })
+  })
+
+  describe('when a product is not sponsored', () => {
+    const product = ProductFactory.build({}, { isSponsored: false }) as Product
+
+    it('should render the ProductSummary component passed as prop', () => {
+      const { getByTestId } = setupTest(product)
+
+      expect(getByTestId(testId)).toBeInTheDocument()
+    })
+
+    it('should not add a wrapper with the data properties', () => {
+      const { queryByTestId } = setupTest(product)
+
+      expect(queryByTestId('ads-analytics')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/react/components/AdsAnalytics/index.tsx
+++ b/react/components/AdsAnalytics/index.tsx
@@ -1,0 +1,1 @@
+export * from './AdsAnalytics'

--- a/react/components/AdsAnalytics/utils/__tests__/getDataProperties.test.ts
+++ b/react/components/AdsAnalytics/utils/__tests__/getDataProperties.test.ts
@@ -1,0 +1,37 @@
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+import ProductFactory from '../../../../__testUtils__/factories/product'
+import getDataProperties from '../getDataProperties'
+
+const position = 1
+
+describe('#getDataProperties', () => {
+  describe('when product is  sponsored', () => {
+    const product = ProductFactory.build() as Product
+
+    it('returns the correct data properties to be added to the HTML', () => {
+      const dataProperties = getDataProperties({ product, position })
+
+      expect(dataProperties).toMatchObject({
+        'data-van-prod-id': product.productId,
+        'data-van-prod-name': product.productName,
+        'data-van-position': position,
+        'data-van-aid': product.advertisement.adId,
+        'data-van-cid': product.advertisement.campaignId,
+        'data-van-req-id': product.advertisement.adRequestId,
+        'data-van-res-id': product.advertisement.adResponseId,
+        'data-van-cpc': product.advertisement.actionCost,
+      })
+    })
+  })
+
+  describe('when product is not sponsored', () => {
+    const product = ProductFactory.build({}, { isSponsored: false }) as Product
+
+    it('returns undefined', () => {
+      const dataProperties = getDataProperties({ product, position })
+
+      expect(dataProperties).toBeUndefined()
+    })
+  })
+})

--- a/react/components/AdsAnalytics/utils/getDataProperties.ts
+++ b/react/components/AdsAnalytics/utils/getDataProperties.ts
@@ -1,0 +1,35 @@
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+import { isSponsored } from '../../../utils'
+import { DataProperties } from '../AdsAnalytics.types'
+
+type GetDataPropertiesArgs = {
+  product: Product
+  position: number
+}
+
+const getDataProperties = ({
+  product,
+  position,
+}: GetDataPropertiesArgs): Nullable<DataProperties> => {
+  if (!isSponsored(product)) return
+
+  const {
+    productId,
+    productName,
+    advertisement: { adId, campaignId, adRequestId, adResponseId, actionCost },
+  } = product
+
+  return {
+    'data-van-prod-id': productId,
+    'data-van-prod-name': productName,
+    'data-van-position': position,
+    'data-van-aid': adId,
+    'data-van-cid': campaignId,
+    'data-van-req-id': adRequestId,
+    'data-van-res-id': adResponseId,
+    'data-van-cpc': actionCost,
+  }
+}
+
+export default getDataProperties

--- a/react/components/AdsAnalytics/utils/index.ts
+++ b/react/components/AdsAnalytics/utils/index.ts
@@ -1,0 +1,3 @@
+import getDataProperties from './getDataProperties'
+
+export { getDataProperties }

--- a/react/utils/__tests__/isSponsored.test.ts
+++ b/react/utils/__tests__/isSponsored.test.ts
@@ -1,0 +1,22 @@
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+import ProductFactory from '../../__testUtils__/factories/product'
+import isSponsored from '../isSponsored'
+
+describe('#isSponsored', () => {
+  describe('when the product is sponsored', () => {
+    const product = ProductFactory.build() as Product
+
+    it('should return true', () => {
+      expect(isSponsored(product)).toBe(true)
+    })
+  })
+
+  describe('when the product is not sponsored', () => {
+    const product = ProductFactory.build({}, { isSponsored: false }) as Product
+
+    it('should return true', () => {
+      expect(isSponsored(product)).toBe(false)
+    })
+  })
+})

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -1,0 +1,3 @@
+import isSponsored from './isSponsored'
+
+export { isSponsored }

--- a/react/utils/isSponsored.ts
+++ b/react/utils/isSponsored.ts
@@ -1,0 +1,5 @@
+import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+const isSponsored = (product: Product) => !!product?.advertisement?.adId
+
+export default isSponsored

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,0 +1,5 @@
+{
+  "ads-analytics": {
+    "component": "AdsAnalytics"
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

Implements a block that wraps the ProductSummary component, passed as prop. It adds the necessary data-properties so that the Activity Flow script can listen and collect metrics.

#### How to test it?

Inspecting the sponsored product in this workspace reveals the data properties.

[Workspace](https://caula--storecomponents.myvtex.com/fashion?_q=fashion&map=ft)
