### PR TITLE
Feature: gets product from context if not passed as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- If the product is not passed as prop to `ads-analytics`, gets it from context.
+
 ## [0.1.0] - 2023-10-06
 
 ### Added

--- a/react/components/AdsAnalytics/AdsAnalytics.tsx
+++ b/react/components/AdsAnalytics/AdsAnalytics.tsx
@@ -1,14 +1,20 @@
 import React from 'react'
+import { ProductSummaryContext } from 'vtex.product-summary-context'
 
 import { isSponsored } from '../../utils'
 import { AdsAnalyticsProps } from './AdsAnalytics.types'
 import { getDataProperties } from './utils'
 
+const { useProductSummary } = ProductSummaryContext
+
 export const AdsAnalytics = ({
   ProductSummary,
   ...productSummaryProps
 }: AdsAnalyticsProps) => {
-  const { product, position } = productSummaryProps
+  const { product: productFromContext } = useProductSummary()
+  const { product: productFromProps, position } = productSummaryProps
+
+  const product = productFromProps ?? productFromContext
 
   if (!isSponsored(product)) return <ProductSummary {...productSummaryProps} />
 

--- a/react/components/AdsAnalytics/AdsAnalytics.types.tsx
+++ b/react/components/AdsAnalytics/AdsAnalytics.types.tsx
@@ -1,8 +1,8 @@
 import { ProductSummaryTypes } from 'vtex.product-summary-context'
 
 type ProductSummaryProps = {
-  product: ProductSummaryTypes.Product
-  position: number
+  product?: ProductSummaryTypes.Product
+  position?: number
   [x: string]: unknown
 }
 
@@ -13,7 +13,7 @@ export type AdsAnalyticsProps = {
 export type DataProperties = {
   'data-van-prod-id': string
   'data-van-prod-name': string
-  'data-van-position': number
+  'data-van-position': Nullable<number>
   'data-van-aid': string
   'data-van-cid': string
   'data-van-req-id': string

--- a/react/components/AdsAnalytics/__tests__/AdsAnalytics.test.tsx
+++ b/react/components/AdsAnalytics/__tests__/AdsAnalytics.test.tsx
@@ -1,7 +1,11 @@
 import '@testing-library/jest-dom'
 import { render } from '@vtex/test-tools/react'
 import React from 'react'
-import { Product } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+import { ProductSummaryContext } from 'vtex.product-summary-context'
+import {
+  Product,
+  State,
+} from 'vtex.product-summary-context/react/ProductSummaryTypes'
 
 import ProductFactory from '../../../__testUtils__/factories/product'
 import { AdsAnalytics } from '../AdsAnalytics'
@@ -11,11 +15,21 @@ const MockProductSummary = () => <div data-testid={testId}>ProductSummary</div>
 
 const position = 1
 
-const setupTest = (product: Product) => {
+type Options = {
+  fromContext?: boolean
+}
+
+const setupTest = (product: Product, { fromContext }: Options = {}) => {
+  jest
+    .spyOn(ProductSummaryContext, 'useProductSummary')
+    .mockImplementation(() => ({ product } as State))
+
+  const propProduct = fromContext ? undefined : product
+
   return render(
     <AdsAnalytics
       ProductSummary={MockProductSummary}
-      product={product}
+      product={propProduct}
       position={position}
     />
   )
@@ -70,6 +84,16 @@ describe('<AdsAnalytics />', () => {
       const { queryByTestId } = setupTest(product)
 
       expect(queryByTestId('ads-analytics')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the product is not passed as prop', () => {
+    const product = ProductFactory.build() as Product
+
+    it('should get the product from the context', () => {
+      const { getByTestId } = setupTest(product, { fromContext: true })
+
+      expect(getByTestId(testId)).toBeInTheDocument()
     })
   })
 })

--- a/react/components/AdsAnalytics/utils/getDataProperties.ts
+++ b/react/components/AdsAnalytics/utils/getDataProperties.ts
@@ -5,7 +5,7 @@ import { DataProperties } from '../AdsAnalytics.types'
 
 type GetDataPropertiesArgs = {
   product: Product
-  position: number
+  position?: number
 }
 
 const getDataProperties = ({


### PR DESCRIPTION
#### What problem is this solving?

Some accounts use `blocks` instead of the `layouts.ListLayout` and `layouts.GridLayout` to display the search results gallery. In these cases, we can't pass the `ads-analytics` as block.

Instead, we use it as a child of the `product-summary` passed in the `blocks` list. Therefore, all the props passed directly to `<ProductSummary />` do not reach the `<AdsAnalytics />`.

So, if the product is not passed as prop, we get it from the context.
